### PR TITLE
fixed pickle protocol version

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -25,4 +25,4 @@ for modelName in models:
     print('Converting %s'%modelName)
     newModelName = gensimDir + os.path.basename(modelName)
     model = gensim.models.KeyedVectors.load_word2vec_format(modelName, binary=True)
-    model.save(newModelName)
+    model.save(newModelName, pickle_protocol=2)


### PR DESCRIPTION
The 2023 version of pickle protocol used in gensim-created vectors (4) does not agree with ShiCo. Therefore the historic pickle protocol version (2) was added as a requirement in the file `convert.py`, line 28.