### PR TITLE
fixed start on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ where DOI can be:
 |---|---|
 | times | https://doi.org/10.5281/zenodo.1494140 |
 | kb    | https://doi.org/10.5281/zenodo.1189327 |
-| German historic newspapers* | https://doi.org/10.5281/zenodo.3255285 |
+| German historic newspapers\* | https://doi.org/10.5281/zenodo.3255285 |
 
 **Note:** German newspapers contains 3 sets of `chronicling_america`, `europeana` and `sbb`, which can be deployed separately.
 
@@ -47,4 +47,4 @@ Run the `start.sh` bash script:
 ./start.sh
 ```
 
-You should now have a ShiCo backend running on port 8000 and frontend running on port 3000 of your localhost. Visit http://localhost:3000/ to use your instance of ShiCo.
+(or `./start.sh windows` if you are on Microsoft Windows) You should now have a ShiCo backend running on port 8000 and frontend running on port 3000 of your localhost. Visit http://localhost:3000/ to use your instance of ShiCo.

--- a/getcwd-windows.py
+++ b/getcwd-windows.py
@@ -1,0 +1,11 @@
+# converts a current directory name like C:\Users\Erikt\ShiCo-deploy to //c/users/erikt/shico-deploy
+
+import os
+import re
+
+pwd = os.getcwd()
+pwd = re.sub("\\\\", "/", pwd)
+pwd = re.sub(":", "", pwd)
+pwd = re.sub("^", "//", pwd)
+pwd = pwd.lower()
+print(pwd)

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
-docker run -d --rm --name shico_backend -p 8000:8000 -v $PWD/gensim/:/home/shico/word2vec/ -v $PWD/backend/:/tmp/config/ "cmartinez/shico"
-docker run -d --rm --name shico_front -p 3000:3000 -v $PWD/frontend/:/tmp/config/ "cmartinez/shico-frontend"
+
+if [ "$1" = "windows" ]
+then
+   CURRENT_DIR=`python3 getcwd-windows.py`
+else
+   CURRENT_DIR=$PWD
+fi
+
+docker run -d --rm --name shico_backend -p 8000:8000 -v $CURRENT_DIR/gensim/:/home/shico/word2vec/ -v $CURRENT_DIR/backend/:/tmp/config/ "cmartinez/shico"
+docker run -d --rm --name shico_front -p 3000:3000 -v $CURRENT_DIR/frontend/:/tmp/config/ "cmartinez/shico-frontend"


### PR DESCRIPTION
## Motivation

The `startup.sh` script does not work on Microsoft Windows because of the different format of path names

## Changes

1. introduced `getcwd-windows.py` for converting the path to the required Microsoft Windows format
2. called `getcwd-windows.py` from `start.sh` when windows is specified as command line argument
3. added information on using `start.sh` on Microsoft Windows in the README instructions 